### PR TITLE
feat: create container for e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: dtopuzov
+  CONTAINER_NAME: test-container
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+  # You can see more details on BRANCH_NAME value here:
+  # https://stackoverflow.com/questions/58033366/how-to-get-the-current-branch-within-github-actions
+
+jobs:
+  build:
+    name: Build Container
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          lfs: true
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and Push Container
+        uses: docker/build-push-action@v5.0.0
+        with:
+          context: ./${{ env.CONTAINER_NAME }}
+          tags: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.CONTAINER_NAME }}:${{ env.BRANCH_NAME }}
+          push: true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # docker-images
+
+Example how to build and publish docker images in GitHub registry.
+
+## test-container
+
+The name of the container in this example is `test-container` and it is based on Debian 11 base image.
+
+List of additionally installed software:
+
+- JDK 11
+- NodeJS 18
+- Chromium (and Chromedriver)
+- Firefox (and Geckodriver)
+- [Xvfb](https://en.wikipedia.org/wiki/Xvfb) to emulate display in case you need to run tests in non headless mode

--- a/test-container/Dockerfile
+++ b/test-container/Dockerfile
@@ -1,0 +1,53 @@
+# Use base Debian 11 (bullseye) image, see https://hub.docker.com/_/debian
+FROM debian:bullseye 
+
+# See Dockerfile support for GitHub Actions
+# https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions
+
+# Install additional packages
+ENV DEBIAN_FRONTEND=noninteractive
+RUN sed -i -e "s/ main[[:space:]]*\$/ main contrib/" /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y tzdata apt-transport-https bzip2 rsync ca-certificates curl gnupg openssh-client git jq sudo zip unzip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install JDK
+RUN apt-get update \
+    && apt-get install -y openjdk-11-jdk openjdk-11-jre \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js
+RUN curl -sL https://deb.nodesource.com/setup_18.x | sudo bash - \
+    && apt-get install -y nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Chromium & Chromedriver
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends chromium chromium-driver \
+    && ln -s /usr/bin/chromium /usr/bin/chrome \
+    && ln -s /usr/bin/chromium /usr/bin/chromium-browser
+
+# Install Firefox & Geckodriver
+ARG firefox_ver=113.0
+ARG geckodriver_ver=0.33.0
+RUN apt-get update \
+    # Install dependencies for Firefox
+    && apt-get install -y --no-install-recommends --no-install-suggests `apt-cache depends firefox-esr | awk '/Depends:/{print$2}'` libasound2 libxt6 libxtst6 \
+    # Download and install Firefox
+    && curl -fL https://ftp.mozilla.org/pub/firefox/releases/${firefox_ver}/linux-x86_64/en-GB/firefox-${firefox_ver}.tar.bz2 | tar xjf - -C /opt \
+    && ln -s /opt/firefox/firefox /usr/bin/firefox \
+    && firefox --version \
+    # Download and install geckodriver
+    && curl -fL https://github.com/mozilla/geckodriver/releases/download/v${geckodriver_ver}/geckodriver-v${geckodriver_ver}-linux64.tar.gz | tar xzf - -C /usr/bin \
+    && chmod +x /usr/bin/geckodriver \
+    && geckodriver --version \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# Install xvfb
+RUN apt-get update \
+    && apt-get install -y xvfb \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add `test-container`, based on Debian 11 base image.

List of additionally installed software:

- JDK 11
- NodeJS 18
- Chromium (and Chromedriver)
- Firefox (and Geckodriver)
- [Xvfb](https://en.wikipedia.org/wiki/Xvfb) to emulate display in case you need to run tests in non headless mode
